### PR TITLE
REVIEW ONLY - Upgrade path to 3.6

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,7 +1,7 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
 version: 3.5.2
-appVersion: 3.6
+appVersion: 3.4
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.
 icon: https://webassets.mongodb.com/_com_assets/cms/mongodb-logo-rgb-j6w271g1xn.jpg

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -35,8 +35,6 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      securityContext:
-{{ toYaml .Values.securityContext | indent 8 }}
       initContainers:
         - name: copy-config
           image: busybox
@@ -47,6 +45,8 @@ spec:
             - |
               set -e
               set -x
+
+              chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} /data/db
 
               cp /configdb-readonly/mongod.conf /data/configdb/mongod.conf
 
@@ -66,6 +66,8 @@ spec:
               mountPath: /configdb-readonly
             - name: configdir
               mountPath: /data/configdb
+            - name: datadir
+              mountPath: /data/db
           {{- if .Values.tls.enabled }}
             - name: ca
               mountPath: /ca-readonly
@@ -83,6 +85,8 @@ spec:
             - name: workdir
               mountPath: /work-dir
         - name: bootstrap
+          securityContext:
+{{ toYaml .Values.securityContext | indent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           command:
             - /work-dir/peer-finder
@@ -137,6 +141,8 @@ spec:
               mountPath: /data/db
       containers:
         - name: {{ template "mongodb-replicaset.name" . }}
+          securityContext:
+{{ toYaml .Values.securityContext | indent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         {{- if .Values.extraVars }}

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -155,7 +155,6 @@ spec:
             - --dbpath=/data/db
             - --replSet={{ .Values.replicaSetName }}
             - --port=27017
-            - --bind_ip=0.0.0.0
           {{- if .Values.auth.enabled }}
             - --auth
             - --keyFile=/data/configdb/key.txt

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -27,7 +27,7 @@ installImage:
 # Specs for the MongoDB image
 image:
   repository: mongo
-  tag: 3.6
+  tag: 3.4
   pullPolicy: IfNotPresent
 
 # Additional environment variables to be set in the container


### PR DESCRIPTION
DO NOT MERGE - REVIEW ONLY
- Reverts back to 3.4 compatibility so it can be used in Zenko with Prometheus metrics
- Allows upgrade path from 3.4 to 3.6 which will allow us to use the upstream chart ZENKO-914